### PR TITLE
Add support for `%s` in query paths.

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -24,7 +24,11 @@ chrome.webRequest.onBeforeRequest.addListener(
             }
             var query = activeMappings[url.hostname + "-q"];
             if (query) {
-                destination = destination + query + path
+                if (query.includes('%s')) {
+                    destination = (destination + query).replace('%s', path)
+                } else {
+                    destination = destination + query + path
+                }
             }
         }
 

--- a/js/map.js
+++ b/js/map.js
@@ -1,8 +1,8 @@
 const defaultMap = {
     "b": "https://github.com/issues/assigned",
     "b-q": null,
-    "c": "https://calendar.google.com/calendar/r",
-    "c-q": "/search?q=",
+    "c": "https://calendar.google.com",
+    "c-q": "/calendar/embed?src=%s%40gmail.com",
     "cl": "https://github.com/pulls",
     "cl-q": null,
     "cs": "https://github.com/search",

--- a/options.html
+++ b/options.html
@@ -29,6 +29,11 @@
     <div id="viewAll">
         <a href="go_all.html">View go/ shortcuts</a>
     </div>
+    <div>
+            if <code>%s</code> added to <b>Query</b>, <code>%s</code> is replaced
+            by the short-url's path. If no <code>%s</code> found, the short-url's path is
+            simply appended to the <b>Query</b>.
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
This is mainly used for c/<username>, but could be useful for other ones as well (lookin' at you, `b/` + jira)